### PR TITLE
Deploy HTML page to GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,20 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: .

--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # firstgens-cost-analysis-site
 This repository hosts the analysis and development plan for the FirstGens platform, focusing on the tools and features required to build and scale the platform effectively. The HTML page included in this repository provides a detailed breakdown of the costs, benefits, and potential challenges associated with various development approaches.
+
+The HTML page is now deployed to GitHub Pages. You can view it at the following URL:
+
+[FirstGens Platform Cost Analysis](https://andiekobbietks.github.io/firstgens-cost-analysis-site/)

--- a/index.html
+++ b/index.html
@@ -1,0 +1,145 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>FirstGens Platform Analysis</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+            line-height: 1.6;
+            color: #333;
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 20px;
+            background-color: #f5f5f5;
+        }
+        .container {
+            background-color: white;
+            padding: 30px;
+            border-radius: 8px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }
+        h1 {
+            color: #2c3e50;
+            text-align: center;
+            margin-bottom: 30px;
+        }
+        h2 {
+            color: #34495e;
+            border-bottom: 2px solid #eee;
+            padding-bottom: 10px;
+            margin-top: 30px;
+        }
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            margin: 20px 0;
+            background-color: white;
+        }
+        th, td {
+            border: 1px solid #ddd;
+            padding: 12px;
+            text-align: left;
+        }
+        th {
+            background-color: #f8f9fa;
+            font-weight: 600;
+        }
+        tr:hover {
+            background-color: #f8f9fa;
+        }
+        @media (max-width: 768px) {
+            body {
+                padding: 10px;
+            }
+            .container {
+                padding: 15px;
+            }
+            table {
+                display: block;
+                overflow-x: auto;
+                white-space: nowrap;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>FirstGens Platform Development Analysis</h1>
+        
+        <h2>Costing Analysis</h2>
+        <table>
+            <tr>
+                <th>Tool/Feature</th>
+                <th>Purpose</th>
+                <th>Cost</th>
+            </tr>
+            <tr>
+                <td>Circle</td>
+                <td>Hosts community features (mentor directory, live events, discussions)</td>
+                <td>£39–£399/month</td>
+            </tr>
+            <tr>
+                <td>Notion</td>
+                <td>Stores mentor and user data</td>
+                <td>£0–£8/user/month</td>
+            </tr>
+            <tr>
+                <td>Netlify</td>
+                <td>Hosts website and makes it accessible online</td>
+                <td>£0–£19/month</td>
+            </tr>
+            <tr>
+                <td>Custom Backend</td>
+                <td>Replaces Notion with a dedicated database for scalability</td>
+                <td>£50,000–£200,000+ (one-time)</td>
+            </tr>
+            <tr>
+                <td>AI Integration</td>
+                <td>Personalises content for users</td>
+                <td>£500–£5,000/month</td>
+            </tr>
+            <tr>
+                <td>Cloud Hosting</td>
+                <td>Handles increased traffic and data</td>
+                <td>£200–£2,000/month</td>
+            </tr>
+            <tr>
+                <td>Development Team</td>
+                <td>Ongoing updates, bug fixes, and new features</td>
+                <td>£10,000–£50,000/month</td>
+            </tr>
+        </table>
+
+        <h2>Pros and Cons</h2>
+        <table>
+            <tr>
+                <th>Approach</th>
+                <th>Pros</th>
+                <th>Cons</th>
+            </tr>
+            <tr>
+                <td>Starting with Circle, Notion, and Netlify for MVP</td>
+                <td>Rapid deployment, user-friendly, cost-effective</td>
+                <td>Limited customisation and scalability</td>
+            </tr>
+            <tr>
+                <td>Transitioning to a custom solution as the platform grows</td>
+                <td>Full control over features and scalability, protection of intellectual property</td>
+                <td>Higher upfront and ongoing costs, requires technical expertise</td>
+            </tr>
+            <tr>
+                <td>Integrating third-party AI services</td>
+                <td>Personalised user experience, faster implementation</td>
+                <td>Ongoing costs, dependence on external providers</td>
+            </tr>
+            <tr>
+                <td>Building a custom AI solution</td>
+                <td>Tailored to specific needs, full control over the technology</td>
+                <td>Significant development time and resources required</td>
+            </tr>
+        </table>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
Add HTML page containing the analysis of the FirstGens Platform, including a costing analysis and a pros and cons section, and deploy it to GitHub Pages.

* **index.html**
  - Add the HTML page with the provided content for the analysis of the FirstGens Platform.
* **README.md**
  - Update to include the URL of the deployed GitHub Pages site.
* **.github/workflows/deploy.yml**
  - Add GitHub Actions workflow file for deploying to GitHub Pages.
  - Use `actions/checkout@v2` to check out the repository.
  - Use `peaceiris/actions-gh-pages@v3` to deploy to GitHub Pages.
  - Set the `publish_dir` to `.` to deploy the root directory.

