### PR TITLE
Fix deploy permissions for GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -16,5 +19,5 @@ jobs:
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.ACTIONS_DEPLOY_KEY }}
           publish_dir: .


### PR DESCRIPTION
Update GitHub Actions workflow to fix deployment permission errors.

* **Permissions**: Add a `permissions` section to grant `write` access to the `contents`.
* **Token**: Update the `github_token` to use `${{ secrets.ACTIONS_DEPLOY_KEY }}` instead of `${{ secrets.GITHUB_TOKEN }}`.

