### PR TITLE
Fix GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,8 +16,19 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build the project
+        run: npm run build
+
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
-          github_token: ${{ secrets.ACTIONS_DEPLOY_KEY }}
-          publish_dir: .
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist


### PR DESCRIPTION
Update the GitHub Actions workflow for deploying to GitHub Pages.

* Add a step to set up Node.js using `actions/setup-node@v2`.
* Add a step to install dependencies using `npm install`.
* Add a step to build the project using `npm run build`.
* Update the `github_token` to use `${{ secrets.GITHUB_TOKEN }}`.
* Update the `publish_dir` to `./dist`.

